### PR TITLE
Bug in excel file created for Attack Logs

### DIFF
--- a/CustomAmmoCategories/AdvWeaponHitInfo.cs
+++ b/CustomAmmoCategories/AdvWeaponHitInfo.cs
@@ -1176,7 +1176,7 @@ namespace CustAmmoCategories {
             AdvWeaponHitInfo advInfo = weaponHitInfo[groupIndex][weaponIndex].Value.advInfo();
             foreach (var aCrits in advInfo.resolveInfo) {
               foreach (var advCrit in aCrits.Value.Crits) {
-                critWS.Cells[critLogIndex, 1].Value = advInfo.Sequence;
+                critWS.Cells[critLogIndex, 1].Value = advInfo.Sequence.id;
                 critWS.Cells[critLogIndex, 2].Value = time;
                 critWS.Cells[critLogIndex, 3].Value = new Text(advInfo.Sequence.attacker.DisplayName).ToString();
                 critWS.Cells[critLogIndex, 4].Value = advInfo.weapon.UIName;


### PR DESCRIPTION
In the excel file created, the crit's tab has an attack sequence id. Currently, it's generating  `BattleTech.AttackDirector+AttackSequence` instead of providing the actual sequence id.

The damage part of the spreadsheet uses the id on a line a bit above it [here](https://github.com/BattletechModders/CustomAmmoCategories/blob/743f1c76e2cebdb34b690b1908ce9ac3de78ea69/CustomAmmoCategories/AdvWeaponHitInfo.cs#L1140) on line 1140.

Not important or high priority, but rather than report it, I figured a little PR might be better.