### PR TITLE
- Process alternates does not propagated the originalId, which causes…

### DIFF
--- a/CustomUnits/CustomRepresentation/CustomRepresentation.cs
+++ b/CustomUnits/CustomRepresentation/CustomRepresentation.cs
@@ -2220,7 +2220,7 @@ namespace CustomUnits {
           return CustomActorRepresentationHelper.ProcessSquadBattle(dataManager, ref result, id, custRepDef, chassisDef);
         } else {
           if (setupAlternates) {
-            return CustomActorRepresentationHelper.ProcessAlternatesBattle(dataManager, ref result, id, custRepDef, chassisDef);
+            return CustomActorRepresentationHelper.ProcessAlternatesBattle(dataManager, ref result, origId, custRepDef, chassisDef);
           } else {
             if (setupQuad) {
               return CustomActorRepresentationHelper.ProcessQuadBattle(dataManager, ref result, id, custRepDef, chassisDef);


### PR DESCRIPTION
… the recursive PooledInstantiate_CustomMechRep_Battle to instantiate the donor mech instead of custom mech.