### PR TITLE
Add unrecoverable jam flag

### DIFF
--- a/AdditionalFiles/CAC/README.txt
+++ b/AdditionalFiles/CAC/README.txt
@@ -766,6 +766,7 @@ new fields
 						   mode have priority, than ammo, than weapon. Default value Linear
   "DamageOnJamming": true/false, - if true on jamming weapon will be damaged
   "DestroyOnJamming": true/false, - if true on jamming weapon will be destroyed (need DamageOnJamming to be set true also)
+  "PersistentJamming": true/false, - if true weapon will be jammed until end of combat. No attemts of jamming will be done at all
   "FlatJammingChance": 1.0, - Chance of jamming weapon after fire. 1.0 is jamm always. Unjamming logic implemented as in WeaponRealizer
                               NOTE! There FlatJammingChance can be altered via CACFlatJammingChance statistic value per actor's and/or per weapon's statistic collections
   "RecoilJammingChance": 0.0, - addition to  FlatJammingChance based on recoil. Adds RecoilJammingChance * <RefireModifier> to FlatJammingChance

--- a/CustomAmmoCategories/Jamming.cs
+++ b/CustomAmmoCategories/Jamming.cs
@@ -183,7 +183,7 @@ namespace CustAmmoCategories {
 
       foreach (Weapon weapon in actor.Weapons) {
         if (weapon.roundsSinceLastFire <= 0) { continue; };
-        if (CustomAmmoCategories.IsJammed(weapon)) {
+        if (CustomAmmoCategories.IsJammed(weapon) && !weapon.JammingPersistent()) {
           var removedJam = CustomAmmoCategories.AttemptToRemoveJam(actor, weapon);
           Log.Combat?.WL(0, $"Removed Jam? {removedJam}");
         }
@@ -528,6 +528,10 @@ namespace CustAmmoCategories {
     }
     public static int Cooldown(this Weapon weapon) {
       return weapon.exDef().Cooldown + weapon.mode().Cooldown;
+    }
+    public static bool JammingPersistent(this Weapon weapon)
+    {
+       return weapon.exDef().PersistentJamming;
     }
     public static bool AttemptToRemoveJam(AbstractActor actor, Weapon weapon) {
       var skill = actor.SkillGunnery;

--- a/CustomAmmoCategories/WeaponDef.cs
+++ b/CustomAmmoCategories/WeaponDef.cs
@@ -747,6 +747,8 @@ namespace CustAmmoCategories {
     public float LongRangeClusterMod { get; set; } = 0f;
     [Key(143), StatCollectionFloat]
     public float MaxRangeClusterMod { get; set; } = 0f;
+    [Key(144)]
+    public bool PersistentJamming { get; set; } = false;
     [IgnoreMember, JsonIgnore]
     private HashSet<string> f_restrictedAmmo = null;
     [IgnoreMember, JsonIgnore]


### PR DESCRIPTION
Rapid-fire weapons in TT in case of jam will be jammed until end of combat. Only rotary autocannons could be unjammed on next turn

This PR adds flag that adds similar behavior to weapon jamming