### PR TITLE
New boolean flag for controlling ronin piloting class generation

### DIFF
--- a/CustomUnits/Core.cs
+++ b/CustomUnits/Core.cs
@@ -81,6 +81,7 @@ namespace CustomUnits {
     public int MaxVehicleRandomPilots { get; set; }
     public string CanPilotVehicleDescription { get; set; }
     public string CanPilotBothDescription { get; set; }
+    public bool GenerateExtraPilotingClassesForRonin { get; set; }
     public bool ShowVehicleBays { get; set; }
     public int ArgoBaysFix { get; set; }
     public bool BaysCountExternalControl { get; set; }
@@ -240,6 +241,7 @@ namespace CustomUnits {
       CanPilotAlsoMechProbability = 0.0f;
       CanPilotVehicleDescription = String.Format(HumanDescriptionDef.PilotGenDetailFormatting, "Piloting", "Can pilot only vehicles");
       CanPilotBothDescription = String.Format(HumanDescriptionDef.PilotGenDetailFormatting, "Piloting", "Can pilot both mechs and vehicles"); ;
+      GenerateExtraPilotingClassesForRonin = true;
       EMPLOYER_LANCE_GUID = "ecc8d4f2-74b4-465d-adf6-84445e5dfc230";
       CountContractMaxUnits4AsUnlimited = false;
       PlayerControlConvoyTag = "convoy_player_control";


### PR DESCRIPTION
- Added a new boolean flag that will disable generating piloting classes for Ronin. Only classes specified in JSON will given. Starting roster ronin are exempt to ensure all starting units can be piloted.