### PR TITLE
fix some cu settings persisting, even if changed in mod.json

### DIFF
--- a/CustomUnits/CustomHangarDef.cs
+++ b/CustomUnits/CustomHangarDef.cs
@@ -293,7 +293,7 @@ namespace CustomUnits {
               GameObject.DestroyImmediate(child.gameObject);
             }
             layout_bays.gameObject.SetActive(false);
-            foreach(MechBayRowWidget row in Traverse.Create(this.BayPanel).Field<MechBayRowGroupWidget>("bayGroupWidget").Value.Bays) {
+            foreach(MechBayRowWidget row in this.BayPanel.bayGroupWidget.Bays) {
               row.transform.SetParent(gridGO.transform);
             }
             ScrollRect scroll = layout_baysScroller.GetComponent<ScrollRect>();

--- a/CustomUnits/Settings.cs
+++ b/CustomUnits/Settings.cs
@@ -15,7 +15,6 @@ namespace CustomUnits {
   public class CUSettings {
     public string CanPilotVehicleTag { get; set; }
     public string CannotPilotMechTag { get; set; }
-    [GameplaySafe]
     public bool debugLog { get; set; }
     public float DeathHeight { get; set; }
     public bool fixWaterHeight { get; set; }
@@ -23,7 +22,6 @@ namespace CustomUnits {
     public float deepWaterSteepness { get; set; }
     public float deepWaterDepth { get; set; }
     public float waterFlatDepth { get; set; }
-    [GameplaySafe]
     public List<string> LancesIcons { get; set; }
     public List<CustomLanceDef> Lances { get; set; }
     public int overallDeploySize { get; set; }
@@ -161,7 +159,6 @@ namespace CustomUnits {
     public List<string> mechForcedTags { get; set; }
     public List<string> squadForcedTags { get; set; }
     public List<string> navalForcedTags { get; set; }
-    [GameplaySafe]
     public int baysWidgetsCount { get; set; }
     public List<string> forcedLance { get; set; } = new List<string>();
     public string DefaultMeleeDefinition { get; set; } = "Weapon_MeleeAttack";


### PR DESCRIPTION
settings with the `[GameplaySafe]` attributes are stored in the users modsettings folder, but without `[CustomSettings.IsLocalSetting(true)]` they cannot be changed ingame. this leads to the situation where a change of one of these settings in the mod.json would get ignored in favor of the unchangeable setting from modsettings.