### PR TITLE
fix lance config slots not being locked

### DIFF
--- a/CustomUnits/HUDImprove.cs
+++ b/CustomUnits/HUDImprove.cs
@@ -1074,6 +1074,13 @@ namespace CustomUnits {
         Log.M?.WL(1, "filling list");
         for (int i = 0; i < count; ++i) {
           try {
+            if (__instance.loadoutSlots[i].curLockState == LanceLoadoutSlot.LockState.Full)
+              continue;
+            if (i >= (__instance.activeContract?.Override?.maxNumberOfPlayerUnits ?? 100))
+            {
+              __instance.loadoutSlots[i].SetLockState(LanceLoadoutSlot.LockState.Full);
+              continue;
+            }
             SpawnableUnit unit = lanceUnits[i];
             IMechLabDraggableItem forcedMech = (IMechLabDraggableItem)null;
             if (unit.Unit != null) { forcedMech = __instance.mechListWidget.GetMechDefByGUID(unit.Unit.GUID); }


### PR DESCRIPTION
previously on the lance selection screen, all slots were unlocked, even if the mission was limited to less than maximum mechs.
this can get problematic, if there is also a (per mech) tonnage limitation in the same mission. in that case, it was possible to use only the should-be-locked slots for your mechs, which do not have a tonnage limit on them.