### PR TITLE
Remove checks/sets for irbtmu_immobile_unit tag

### DIFF
--- a/CustomAmmoCategories/Artillery.cs
+++ b/CustomAmmoCategories/Artillery.cs
@@ -10,6 +10,7 @@ using Localize;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using IRBTModUtils.Feature;
 
 namespace CustAmmoCategories {
   public class SelectionStateArtilleryStrike: SelectionStateNoActionAvailable {
@@ -175,11 +176,11 @@ namespace CustAmmoCategories {
       foreach(var weapon in owner.weapons) {
         weaponsEnabledState[weapon] = weapon.IsEnabled;
       }
-      if(this.unit.GetTags().Contains("irbtmu_immobile_unit")) {
+      if(MovementFeature.IsImmobile(unit)) {
         AlreadyImmobilized = true;
       } else {
         AlreadyImmobilized = false;
-        this.unit.EncounterTags.Add("irbtmu_immobile_unit");
+        MovementFeature.SetImmobile(unit, true);
       }
     }
     public void Clear() {
@@ -187,7 +188,7 @@ namespace CustAmmoCategories {
         if(weapon.Value == true) { weapon.Key.EnableWeapon(); };
       }
       if(this.AlreadyImmobilized == false) {
-        this.unit.EncounterTags.Remove("irbtmu_immobile_unit");
+        MovementFeature.SetImmobile(unit, false);
       }
     }
   }

--- a/CustomAmmoCategories/CustomAmmoCategories.csproj
+++ b/CustomAmmoCategories/CustomAmmoCategories.csproj
@@ -35,7 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>12</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/CustomUnits/CustomMovement.cs
+++ b/CustomUnits/CustomMovement.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
 using UnityEngine;
+using IRBTModUtils.Feature;
 
 namespace CustomUnits {
   public static class ActorMovementSequence_MoveTowardDelta {
@@ -226,7 +227,7 @@ namespace CustomUnits {
   public static class Mech_JumpDistance {
     public static void Postfix(Mech __instance, ref float __result) {
       try {
-        if(__instance.GetTags().Contains("irbtmu_immobile_unit")) { __result = 0f; return; }
+        if(MovementFeature.IsImmobile(__instance)) { __result = 0f; return; }
         if(__instance is TrooperSquad squad) {
           int workingJumpjetLocaltions = squad.workingJumpsLocations().Count;
           if (Thread.CurrentThread.isFlagSet("CU_JUMPDISTANCE_DEBUG")) {
@@ -555,7 +556,7 @@ namespace CustomUnits {
   public static class Mech_WorkingJumpjets {
     public static void Postfix(Mech __instance, ref int __result) {
       try {
-        if(__instance.GetTags().Contains("irbtmu_immobile_unit")) { __result = 0; return; }
+        if(MovementFeature.IsImmobile(__instance)) { __result = 0; return; }
         TrooperSquad squad = __instance as TrooperSquad;
         if (squad != null) {
           __result = squad.workingJumpsLocations().Count;


### PR DESCRIPTION
GetTags() is an expensive operation during AI thinking/Combat as it must create and update a new TagSet at least once.

To speed up AI calcs IRBT was changed to no longer check for the irbtmu_immobile_unit tag on units during movement calculations and instead now solely relies on the stat version.

CU made checks for this tag when getting a Mechs Jump Distance and CAC used it to immobilize units when they perform artillery attacks. These checks and sets of the tag have been updated to use new helper methods in IRBTModUtils that check or set the stat instead of using the tag, fixing them for the updated IRBT and increasing performance by removing tagset based checks at the same time.