### PR TITLE
Re-work CU for newer versions of CC

### DIFF
--- a/CustomUnits/CustomUnits.csproj
+++ b/CustomUnits/CustomUnits.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />
-    <Publicize Include="Assembly-CSharp;UnityEngine.UI;UnityEngine.CoreModule;InControl;CustomComponents" />
+    <Publicize Include="Assembly-CSharp;UnityEngine.UI;UnityEngine.CoreModule;InControl" />
     <DoNotPublicize Include="Assembly-CSharp:BattleTech.MechRepresentation;Assembly-CSharp:BattleTech.Mech;Assembly-CSharp:BattleTech.AbstractActor;Assembly-CSharp:BattleTech.PilotableActorRepresentation;Assembly-CSharp:BattleTech.UI.SelectionState;Assembly-CSharp:WeaponEffect;Assembly-CSharp:BattleTech.UI.SelectionStateCommand;Assembly-CSharp:BattleTech.UI.SelectionStateConfirm" />
   </ItemGroup>
   <ItemGroup>

--- a/CustomUnits/VehicleChassisDef.cs
+++ b/CustomUnits/VehicleChassisDef.cs
@@ -33,6 +33,7 @@ using HBS.Collections;
 using System.Collections.Concurrent;
 using MessagePack;
 using CustAmmoCategoriesPatches;
+using CustomComponents.Changes;
 using IRBTModUtils;
 using static BattleTech.Data.DataManager;
 
@@ -1992,7 +1993,7 @@ namespace CustomUnits {
       if(weaponDef.Description == null) { return; }
       string repairKitId = $"repairkit_{weaponDef.Description.Id}";
       if(weaponDef.Is<WeaponRepairKit>() == false) {
-        CustomComponents.Database.AddCustom(weaponDef.Description.Id, new WeaponRepairKit(weaponDef.Description.Id, repairKitId));
+        CCAccessHelper.AddCustom(weaponDef.Description.Id, new WeaponRepairKit(weaponDef.Description.Id, repairKitId));
       }
       if(dataManager.upgradeDefs.Exists(repairKitId)) { return; }
       Log.M?.TWL(0, $"AddWeaponRepairKit {weaponDef.Description.Id}");


### PR DESCRIPTION
some internal methods of CC that CU was trying to access have been re…moved or changed. In order to use newer versions of CC, CU needed to be updated.

CU shouldn't really be accessing the internals of CC like this. to encapsulate this, I have moved all impacted methods/fields into a new CC Access Helper and used reflection, removing the publicizer from running on CC.

This may need to be further enhanced as CC continues to be worked on.

Ideally in the future, the vehicle lab is removed from CU and implemented into CC & ME where it probably belongs.